### PR TITLE
bug fix: common domain size calculation

### DIFF
--- a/airlab/utils/domain.py
+++ b/airlab/utils/domain.py
@@ -144,7 +144,7 @@ def get_joint_domain_images(fixed_image, moving_image, default_value=0, interpol
     spacing = np.minimum(fixed_image.spacing, moving_image.spacing)
 
     # common size
-    size = np.ceil((extent-origin)/spacing).astype(int)
+    size = np.ceil(((extent-origin)/spacing)+1).astype(int)
 
     # Resample images
     # fixed and moving image are resampled in new domain


### PR DESCRIPTION
Since extent:=origin+(size-1)*spacing, when recalculating size it should be size=((extent-origin)/spacing)+1. 