### PR TITLE
LCC function bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.ipynb_checkpoints
+__pycache__
+*.ipynb
+*.egg-info

--- a/airlab/loss/pairwise.py
+++ b/airlab/loss/pairwise.py
@@ -276,7 +276,7 @@ class MI(_PairwiseImageLoss):
     r""" Implementation of the Mutual Information image loss.
 
          .. math::
-            \mathcal{S}_{\text{MI}} := H(F, M) - H(F|M) - H(M|F)
+            \mathcal{S}_{\text{MI}} := H(F) + H(M) - H(F, M)
 
         Args:
             fixed_image (Image): Fixed image for the registration

--- a/airlab/loss/pairwise.py
+++ b/airlab/loss/pairwise.py
@@ -362,7 +362,9 @@ class MI(_PairwiseImageLoss):
         fixed_image_valid = th.masked_select(fixed_image_valid, mask)
         moving_image_valid = th.masked_select(moving_image_valid, mask)
 
-        number_of_pixel = moving_image_valid.shape[0]
+        # number_of_pixel = moving_image_valid.shape[0]
+        # computation of number of pixel is wrong
+        number_of_pixel = np.prod(moving_image_valid.shape)
 
         sample = th.zeros(number_of_pixel, device=self._fixed_image.device,
                           dtype=self._fixed_image.dtype).uniform_() < self._spatial_samples
@@ -383,7 +385,8 @@ class MI(_PairwiseImageLoss):
 
         ent_joint = -(p_joint * th.log2(p_joint + 1e-10)).sum()
 
-        return -(ent_fixed_image + ent_moving_image - ent_joint)
+        # return -(ent_fixed_image + ent_moving_image - ent_joint)
+        return ent_fixed_image + ent_moving_image - ent_joint
 
 class NGF(_PairwiseImageLoss):
     r""" Implementation of the Normalized Gradient Fields image loss.

--- a/airlab/loss/pairwise.py
+++ b/airlab/loss/pairwise.py
@@ -188,7 +188,7 @@ class NCC(_PairwiseImageLoss):
     Local Normaliced Cross Corelation Image Loss
 """
 class LCC(_PairwiseImageLoss):
-    def __init__(self, fixed_image, moving_image,fixed_mask=None, moving_mask=None, sigma=3, kernel_type="box", size_average=True, reduce=True):
+    def __init__(self, fixed_image, moving_image,fixed_mask=None, moving_mask=None, sigma=[3], kernel_type="box", size_average=True, reduce=True):
         super(LCC, self).__init__(fixed_image, moving_image, fixed_mask, moving_mask,  size_average, reduce)
 
         self._name = "lcc"

--- a/airlab/registration/registration.py
+++ b/airlab/registration/registration.py
@@ -99,8 +99,8 @@ class PairwiseRegistration(_PairwiseRegistration):
         lossList = []
         loss_names = []
         for image_loss in self._image_loss:
-             lossList.append(image_loss(displacement))
-             loss_names.append(image_loss.name)
+            lossList.append(image_loss(displacement))
+            loss_names.append(image_loss.name)
 
         # compute the regularisation loss on the displacement
         for reg_disp in self._regulariser_displacement:

--- a/airlab/utils/image.py
+++ b/airlab/utils/image.py
@@ -204,7 +204,7 @@ class Displacement(Image):
         return itk_displacement
 
     def magnitude(self):
-       return Image(th.sqrt(th.sum(self.image.pow(2),  -1)).squeeze(), self.size, self.spacing, self.origin)
+        return Image(th.sqrt(th.sum(self.image.pow(2),  -1)).squeeze(), self.size, self.spacing, self.origin)
 
     def numpy(self):
         return self.image.cpu().numpy()

--- a/airlab/utils/imageLoader.py
+++ b/airlab/utils/imageLoader.py
@@ -30,22 +30,16 @@ class ImageLoader(object):
     The downloaded images are cached in a temporary folder, such that, if the image is loaded twice, it will be taken
     from that folder. If landmark points are available too, they are downloaded and cached as well. The class is
     implemented as singleton in order to hold a database of cached images only once and consistent.
-
     Using the show() method, one can print the different images which can be loaded. They are grouped into subjects
     and images. For example: 4DCT_POPI_2 image_30 means, the subject 4DCT_POPI_2 and the third image of the respiratory
     cycle.
-
     Usage:
     loader = ImageLoader("/tmp/")
     (image, points) = loader.load("4DCT_POPI_2", "image_30")
-
     If no landmark points are defined, points is set to None.
-
     In the generate_database() other images can be registered to the database.
-
     Note: the provided publicly available images have been published for research purposes. If you are using them for
           your research, please cite the authors appropriately.
-
     """
 
     # singleton helper
@@ -89,9 +83,7 @@ class ImageLoader(object):
         """
         Providing the subject name and the image of interest, the image is loaded either from the memory cache, the
         temporary folder or it is downloaded from the internet. Images which are registered in the _database can be loaded.
-
         Note: if no points are available to the image, None is returned as points
-
         name (str): subject name
         image (str): image name
         dtype: which pixel type the image should be converted to
@@ -184,7 +176,6 @@ class ImageLoader(object):
     def clear():
         """
         Delete database of images and the temp directory
-
         Finally, a new temp directory is created
         """
         # clear dict
@@ -229,7 +220,7 @@ class ImageLoader(object):
                 }
                 )
             data[prefix + str(i)]["copyright"] = """
-    Data has been provided by the Léon Bérard Cancer Center & CREATIS lab, Lyon, France.
+    Data has been provided by the LÃ©on BÃ©rard Cancer Center & CREATIS lab, Lyon, France.
     The data is described in:
     
     J. Vandemeulebroucke, S. Rit, J. Kybic, P. Clarysse, and D. Sarrut. 
@@ -241,4 +232,3 @@ class ImageLoader(object):
     """
 
         return data
-


### PR DESCRIPTION
Default value of `sigma=3` in LCC function cannot be indexed even after `np.array(sigma)`. A fix is provide to change it as `sigma=[3]`.