### PR TITLE
Add helper function to convert displacement field tensor into SimpleITK-compatitable DFT

### DIFF
--- a/airlab/transformation/utils.py
+++ b/airlab/transformation/utils.py
@@ -117,7 +117,7 @@ def displacement_to_unit_displacement(displacement):
 """
     Convert a unit displacement to a  itk like displacement
 """
-def unit_displacement_to_dispalcement(displacement):
+def unit_displacement_to_displacement(displacement):
     # scale displacements from 2square
     # domain to image domain
     # - last dimension are displacements


### PR DESCRIPTION
Example Usage:
```{Python}
import airlab as al
import SimpleITK as sitk

# ... registration process with image pyramid
constant_flow = transformation.get_flow()
trans = al.transformation.utils.get_displacement_itk(constant_flow, mov_im_level.itk())
warped = sitk.Resample(moving, fixed, trans, sitk.sitkLinear)
```